### PR TITLE
Idiomatic testing of akka stream

### DIFF
--- a/akka/src/test/scala/io/kagera/akka/AkkaTestBase.scala
+++ b/akka/src/test/scala/io/kagera/akka/AkkaTestBase.scala
@@ -12,7 +12,7 @@ object AkkaTestBase {
       |
       |akka {
       |  loggers = ["akka.testkit.TestEventListener"]
-      |  test.timefactor = 3
+      |  test.timefactor = 4
       |  persistence {
       |    journal.plugin = "inmemory-journal"
       |    snapshot-store.plugin = "inmemory-snapshot-store"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -68,6 +68,7 @@ object Build extends Build {
         scalaGraph,
         akkaInmemoryJournal % "test",
         akkaTestkit % "test",
+        akkaStreamTestKit % "test",
         scalatest   % "test")
     ))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
   val akkaTestkit              = "com.typesafe.akka"               %% "akka-testkit"                        % akkaVersion
   val akkaSlf4j                = "com.typesafe.akka"               %% "akka-slf4j"                          % akkaVersion
   val akkaStream               = "com.typesafe.akka"               %% "akka-stream"                         % akkaVersion
+  val akkaStreamTestKit        = "com.typesafe.akka"               %% "akka-stream-testkit"                 % akkaVersion
   val akkaQuery                = "com.typesafe.akka"               %% "akka-persistence-query-experimental" % akkaVersion
   val akkaHttp                 = "com.typesafe.akka"               %% "akka-http-experimental"              % akkaHttpVersion
   val akkaInmemoryJournal      = "com.github.dnvriend"             %% "akka-persistence-inmemory"           % "1.3.14"


### PR DESCRIPTION
This PR introduces a more idiomatic testing of an Akka Stream for one of the tests in QuerySpec.

The key concept is that you can test a stream by sinking into "TestSink.probe" (i.e. runWith(TestSink.probe) ). 